### PR TITLE
corrects example clustermq.template key

### DIFF
--- a/example.input.yaml
+++ b/example.input.yaml
@@ -17,5 +17,5 @@ bed.file:
 hpc.scheduler: sge
 
 ##optional 
-template: template/sge_template
+clustermq.template: template/sge_template
 


### PR DESCRIPTION
The wrapper script appears to be looking for this as `clustermq.template`, not `template`