### PR TITLE
fix inconsistent conda env name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ EDM depends on several software tools including R packages. We use a conda envir
 ```
 git clone https://github.com/drramki-chop/EDM.git
 conda env create -f edm_conda_env.yml
-conda activate edm_environment
+conda activate edm_env
 ```
 
 ## Step 2: Install EDM package

--- a/edm_conda_env.yml
+++ b/edm_conda_env.yml
@@ -1,4 +1,4 @@
-name: edm_environment
+name: edm_env
 channels:
   - bioconda
   - conda-forge


### PR DESCRIPTION
The submit.sh script calls this `edm_env`, so use that name here as well.

Conversely, could standardize on `edm_environment`, but I went for this route since `edm_env` also seems to be used as a default in the wrapper script within the R module.